### PR TITLE
Fix hook usage for score signing

### DIFF
--- a/src/ScoreSubmit.js
+++ b/src/ScoreSubmit.js
@@ -1,16 +1,24 @@
 
 import React from "react";
-import { useGetAccountInfo, useSignMessage  } from "@multiversx/sdk-dapp";
+import { useGetAccountInfo, useSignMessage } from "@multiversx/sdk-dapp";
 
 export default function ScoreSubmit() {
   const { address } = useGetAccountInfo();
+  // useSignMessage is a React hook and must be called at the top level of
+  // the component. It exposes a `signMessage` function that can be used to
+  // sign arbitrary messages. The previous implementation attempted to call
+  // the hook inside the submit handler which breaks the Rules of Hooks and
+  // causes runtime errors.
+  const { signMessage } = useSignMessage();
 
   const submitScore = async () => {
     const score = Math.floor(Math.random() * 1000);
     const message = `score:${score}`;
 
     try {
-      const { signature } = await useSignMessage(message);
+      // Sign the score message using the signMessage function returned by
+      // the useSignMessage hook.
+      const { signature } = await signMessage({ message });
       const res = await fetch(`${process.env.REACT_APP_API_URL}/submit-score`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
- correctly initialize `useSignMessage` hook and use returned `signMessage` function when submitting score
- add inline comments explaining proper hook usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a14842ebc8329a71826a99605a1d1